### PR TITLE
16.0 update

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,34 +6,49 @@ more than 11 million installations, and is owned by Oracle.
 MySQL is a fast, stable, robust, easy to use, and true multi-user,
 multi-threaded SQL database server.
 
+Strictly speaking, this appliance actually provides MariaDB_. MariaDB
+is generally considered a `drop-in replacement for MySQL`_. However, it
+does have `some features`_ that don't directly map to MySQL. As a general
+rule, it is possible to migrate from MySQL to MariaDB, but oftem not
+possible to go back again.
+
 This appliance includes all the standard features in `TurnKey Core`_,
 and on top of that:
 
-- MariaDB_ (drop-in MySQL replacement)
-- Web Control Panel
+- MariaDB_ (MySQL replacement).
+- Web Control Panel, including "quick start" docs, noting info about SSL
+  MySQL connections.
 - `Adminer`_ administration frontend for MySQL (listening on port
   12322 - uses SSL).
-- MySQL webmin module.
-- MySQL is configured to listen on port 3306 TCP on all interfaces by
-  default.
+- MySQL webmin module (compatible with MariaDB).
+- MySQLTuner_ - Perl script to review and tweak a MySQL/MariaDB
+  installation.
+- Dedicated remote MySQL/MariaDB user; 'remote'.
+- Local 'root' user authenticates via socket, so no password required.
+- MariaDB configured to listen on port 3306 TCP on all interfaces by
+  default - now with SSL enabled (and required) by default.
 - For convenience MySQL is configured to accept connections from all
   hosts by default. In a production environment it is recommended to
   limit incoming connections to specific hosts::
 
     UPDATE `mysql`.`user` SET `Host` = 'hostname' 
     WHERE CONVERT( `user`.`Host` USING utf8 ) = '%' AND 
-    CONVERT( `user`.`User` USING utf8 ) = 'adminer' LIMIT 1 ;
+    CONVERT( `user`.`User` USING utf8 ) = 'remote' LIMIT 1 ;
 
-Note: MySQL can be further tweaked to optimize performance.
+Note: MariaDB can be further tweaked to optimize performance.
 
 Credentials *(passwords set at first boot)*
 -------------------------------------------
 
 -  Webmin, SSH, MySQL (local): username **root**
--  MySQL (remote), Adminer: username **adminer**
+-  Adminer: username **adminer**
+-  MySQL (remote): username **remote**
 
 
-.. _MySQL: http://www.mysql.com/
+.. _MySQL: https://www.mysql.com/
 .. _MariaDB: https://mariadb.com/
+.. _drop-in replacement for MySQL: https://mariadb.com/kb/en/mariadb-vs-mysql-compatibility/
+.. _some features: https://mariadb.com/kb/en/mariadb-vs-mysql-compatibility/#drop-in-compatibility-of-specific-mariadb-versions
 .. _TurnKey Core: https://www.turnkeylinux.org/core
-.. _Adminer: http://adminer.org/
+.. _Adminer: https://adminer.org/
+.. _MySQLTuner: https://github.com/major/MySQLTuner-perl/blob/master/README.md

--- a/changelog
+++ b/changelog
@@ -1,3 +1,35 @@
+turnkey-mysql-16.0 (1) turnkey; urgency=low
+
+  * Updated all relevant Debian packages to Buster/10 versions; including
+    MariaDB & PHP 7.3 (for Adminer).
+
+  * New user account, named "remote" configured for remote connections.
+
+  * Explicitly enabled SSL for MySQL network connections via port 3306.
+
+  * New inithooks to set hostname for remote user host and regenerate MariaDB
+    connection SSL certifcates/keys.
+
+  * CLI script 'turnkey-mysql-ssl' and Confconsole plugin to enable/disable
+    MySQL/MariaDB SSL requirement for remote connections.
+
+  * Explcitly disable TLS<1.2 (i.e. SSLv3, TLSv1, TLSv1.1) for WebCP & Adminer.
+    (v15.x TurnKey releases supported TLS 1.2, but could fallback as low as
+    TLSv1).
+
+  * Update SSL/TLS cyphers webservers to provide "Intermediate" browser/client
+    support (suitable for "General-purpose servers with a variety of clients,
+    recommended for almost all systems"). As provided by Mozilla via
+    https://ssl-config.mozilla.org/.
+
+  * Updated version of mysqltuner script - now installed as per upstream
+    recommendation.
+
+  * Note: Please refer to turnkey-core's changelog for changes common to all
+    appliances. Here we only describe changes specific to this appliance.
+
+ -- Jeremy Davis <jeremy@turnkeylinux.org>  Fri, 10 Jul 2020 16:47:16 +1000
+
 turnkey-mysql-15.1 (1) turnkey; urgency=low
 
   * Rebuild to resolve inadvertent removal of mariadb during sec-updates

--- a/conf.d/main
+++ b/conf.d/main
@@ -1,15 +1,21 @@
 #!/bin/sh -ex
 
-# configure mysql to listen on all interfaces
-sed --in-place "s/^bind-address/#bind-address/" /etc/mysql/mariadb.conf.d/50-server.cnf
+DB_PASS=$(mcookie)
+REMOTE_USER=remote
 
-sed -Ei "s|^(server.document-root.*=).*|\1 \"/var/www\"|" /etc/lighttpd/lighttpd.conf
+# configure mysql to listen on all interfacesq
+sed -i "s|^bind-address|#bind-address|" /etc/mysql/mariadb.conf.d/50-server.cnf
 
-# allow remote connections
+# generate SSL certs for MySQL remote connections (rerun on firstboot)
+/usr/lib/inithooks/firstboot.d/20regen-mysql-certs
+
+# allow remote connections & enable SSL by default
 service mysql start
-mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'adminer'@'%'  WITH GRANT OPTION;"
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO '$REMOTE_USER'@'%' IDENTIFIED BY '$DB_PASS';"
 mysql -u root -e "FLUSH PRIVILEGES;"
+turnkey-mysql-ssl enable
 service mysql stop
 
 # enable tklcp site
+sed -Ei "s|^(server.document-root.*=).*|\1 \"/var/www\"|" /etc/lighttpd/lighttpd.conf
 lighty-enable-mod tklcp || true

--- a/docs/connect-via-ssl.rst
+++ b/docs/connect-via-ssl.rst
@@ -1,0 +1,107 @@
+Connect to MySQL/MariaDB remotely
+=================================
+
+As per all previous releases, by default TurnKey MySQL (MariaDB) appliance
+listens on all interfaces via (default MySQL/MariaDB) port **3306**.
+
+However, since v16.0 there have been some changes...
+
+New remote user username
+------------------------
+
+As of v16.0+ the default "root-like" user is now named "remote".
+
+SSL now enabled (and required) for the "remote" user
+----------------------------------------------------
+
+The SSL requirement is enabled and required for remote connections. If desired
+it can be disabled via the Confconsole plugin (Advanced >> System Settings
+>> MySQL remote SSL) or the 'turnkey-mysql-ssl' commandline tool.
+
+SSL details
+-----------
+
+Self-signed certificates, signed by a custom CA cert are all generated on
+firstboot and stored in '/etc/mysql/certificates'. To connect remotely via SSL,
+you will need to download the relevant files and configure your client to use
+these, or reconfigure it to your desires. The required files are::
+
+   /etc/mysql/certificates/ca.pem # The CA certifcate
+   /etc/mysql/certificates/cert.pem # The certificate file
+   /etc/mysql/certificates/cert.key # The key file
+
+For example, to use the commandline MySQL/MariaDB client from another TurnKey
+instance, assuming that the files have been downloaded to the same local
+locations, the following lines are required in the MySQL/MariaDB client config
+('/etc/mysql/mariadb.conf.d/50-client.cnf')::
+
+   ssl_ca = /etc/mysql/certificates/ca.pem
+   ssl-cert = /etc/mysql/certificates/cert.pem
+   ssl-key = /etc/mysql/certificates/cert.key
+
+Note that the user who is launching the client must have read permission for
+these files.
+
+Once configured, then connection should work as per usual remote MySQL/MariaDB
+connection. E.g.::
+
+   root@core ~# mysql -h remote-mysql.example.com -u remote -p
+   Enter password:
+   Welcome to the MariaDB monitor.  Commands end with ; or \g.
+   Your MariaDB connection id is 41
+   Server version: 10.3.22-MariaDB-0+deb10u1 Debian 10
+
+   Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+   Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+   MariaDB [(none)]>
+
+Then to demonstrate that the connection is encrypted, you can use the '\s'
+command. I.e.::
+
+   MariaDB [(none)]> \s
+   --------------
+   mysql  Ver 15.1 Distrib 10.3.22-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
+
+   Connection id:		41
+   Current database:
+   Current user:		remote@remote-mysql.example.com
+   SSL:			Cipher in use is DHE-RSA-AES256-SHA
+   Current pager:		less -X -R -F
+   Using outfile:		''
+   Using delimiter:	;
+   Server:			MariaDB
+   Server version:		10.3.22-MariaDB-0+deb10u1 Debian 10
+   Protocol version:	10
+   Connection:		192.168.1.74 via TCP/IP
+   Server characterset:	utf8mb4
+   Db     characterset:	utf8mb4
+   Client characterset:	utf8mb4
+   Conn.  characterset:	utf8mb4
+   TCP port:		3306
+   Uptime:			34 min 12 sec
+
+   Threads: 7  Questions: 77  Slow queries: 0  Opens: 32  Flush tables: 1  Open tables: 26  Queries per second avg: 0.037
+   --------------
+
+Note the ciper noted against "SSL:"! :)
+
+Alternate configurations
+------------------------
+
+There are a number of alternate configurations possible (including using
+"proper" CA signed certs) but you are on your own with those for now.
+Please see the `MariaDB "Securing Connections" KB page`_ for further ideas.
+
+If you do configure this appliance to connect via SSL in alternate way and
+would like to share your config (please do!), and/or have any questions
+please feel free to post in the `TurnKey forums`_.
+
+For the most up to date details, please check the `MySQL appliance page`_
+and/or the `docs`_.
+
+.. _MariaDB "Securing Connections" KB page: https://mariadb.com/kb/en/securing-connections-for-client-and-server/
+.. _TurnKey forums: https://www.turnkeylinux.org/forum
+.. _MySQL appliance page: https://www.turnkeylinux.org/mysql
+.. _docs: https://github.com/turnkeylinux-apps/mysql/tree/master/docs

--- a/overlay/etc/confconsole/services.txt
+++ b/overlay/etc/confconsole/services.txt
@@ -3,4 +3,5 @@ Web shell:  https://$ipaddr:12320
 Webmin:     https://$ipaddr:12321
 Adminer:    https://$ipaddr:12322
 SSH/SFTP:   root@$ipaddr (port 22)
-MySQL:      mysql -u adminer -h $ipaddr -p
+MySQL*:     mysql -u remote -h $ipaddr -p
+     * - SSL enabled/required - see docs

--- a/overlay/usr/lib/confconsole/plugins.d/System_Settings/MySQL_Remote_SSL.py
+++ b/overlay/usr/lib/confconsole/plugins.d/System_Settings/MySQL_Remote_SSL.py
@@ -1,0 +1,41 @@
+"""Enable/Disable SSL for MySQL remote connections"""
+
+import subprocess
+import os
+
+SCRIPT_PATH = '/usr/local/bin/turnkey-mysql-ssl'
+
+
+def set_ssl(set_status):
+    subprocess.check_output([SCRIPT_PATH, set_status])
+
+
+def check_status():
+    if os.path.isfile(SCRIPT_PATH) and os.access(SCRIPT_PATH, os.X_OK):
+        exit_code = subprocess.run([SCRIPT_PATH, 'status']).returncode
+        if exit_code == 0:
+            return 'enabled'
+        else:
+            return 'disabled'
+    else:
+        return False
+
+
+def run():
+    status = check_status()
+    if not status:
+        msg = ('The script to toggle SSL for MySQL remote connections is either missing or not executable.\n'
+               'Please investigate or report this issue.')
+        r = console.msgbox('Error', msg)
+    else:
+        msg = '''Automatic certificate renewal is currently {}'''
+        r = console._wrapper('yesno', msg.format(status), 10, 30,
+                             yes_label='Toggle', no_label='Ok')
+        while r == 'ok':
+            if status == 'enabled':
+                set_ssl('disable')
+            else:
+                set_ssl('enable')
+            status = check_status()
+            r = console._wrapper('yesno', msg.format(status), 10, 30,
+                                 yes_label='Toggle', no_label='Ok')

--- a/overlay/usr/lib/inithooks/firstboot.d/20regen-mysql-certs
+++ b/overlay/usr/lib/inithooks/firstboot.d/20regen-mysql-certs
@@ -1,0 +1,29 @@
+#!/bin/bash -ex
+
+# regenerate mysql/mariadb SSL certificates
+
+. /etc/default/inithooks
+
+CERT_DIR=/etc/mysql/certificates
+
+ca_pem=$CERT_DIR/ca.pem
+ca_key=$CERT_DIR/ca.key
+ssl_pem=$CERT_DIR/cert.pem
+ssl_key=$CERT_DIR/cert.key
+ssl_req=$CERT_DIR/req.pem
+
+subj="/C=US/ST=./L=./O='TurnKey MySQL/OU=./CN=./emailAddress=."
+
+mkdir -p $CERT_DIR
+
+openssl genrsa 2048 > $ca_key
+openssl req -new -x509 -nodes -days 365000 -key $ca_key -out $ca_pem -subj "$subj"
+openssl req -newkey rsa:2048 -days 365000 -nodes -keyout $ssl_key -out $ssl_req -subj "$subj"
+openssl rsa -in $ssl_key -out $ssl_key
+openssl x509 -req -in $ssl_req -days 365000 -CA $ca_pem -CAkey $ca_key -set_serial 01 -out $ssl_pem
+
+rm -f $ssl_req
+chown -R mysql:mysql $CERT_DIR
+chmod 400 $CERT_DIR/*
+
+systemctl restart mysql

--- a/overlay/usr/lib/inithooks/firstboot.d/36remote-mysqlpass
+++ b/overlay/usr/lib/inithooks/firstboot.d/36remote-mysqlpass
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+# set mysql root password
+
+. /etc/default/inithooks
+
+[ -e $INITHOOKS_CONF ] && . $INITHOOKS_CONF
+$INITHOOKS_PATH/bin/mysqlconf.py --user=remote --host=% --pass="$DB_PASS"

--- a/overlay/usr/local/bin/turnkey-mysql-ssl
+++ b/overlay/usr/local/bin/turnkey-mysql-ssl
@@ -1,0 +1,93 @@
+#!/bin/bash -e
+
+REMOTE_USER=remote
+INIT=/usr/lib/inithooks/firstboot.d/20regen-mysql-certs
+CONF=/etc/mysql/mariadb.conf.d/50-server.cnf
+CERT_DIR=/etc/mysql/certificates
+
+ca_pem=$CERT_DIR/ca.pem
+ssl_pem=$CERT_DIR/cert.pem
+ssl_key=$CERT_DIR/cert.key
+
+usage() {
+    cat<<EOF
+Syntax: $(basename $0) enable|disable|status|help
+Enable / Disable remote SSL MySQL connections
+
+    enable  Enable SSL for remote MySQL connections
+    disable Disable SSL for remote MySQL connections
+    status  Check status of SSL:
+            - returns msg 'True' & exit code 0 if enabled
+            - returns msg 'False' & exit code 10 if disabled
+    help    Display this help and exit (exit code 1)
+EOF
+exit 1
+}
+
+enable() {
+    # Only re-run the init if the files don't exist
+    if [[ ! -f "$ca_pem" ]] && [[ ! -f "$ssl_key" ]] \
+            && [[ ! -f "$ssl_pem" ]]; then
+        $INIT
+    fi
+
+    sed -i "\|^#ssl[- ]|s|^#||" $CONF
+
+    # If MariaDB is compiled against YaSSL (Debian default) 'ssl-cipher' needs to be disabled.
+    sed -i "\|ssl-cipher|s|^|#|" $CONF
+
+    # If MariaDB compiled against OpenSSL instead, we should explictly set ciphers & disable 'ssl'.
+    #sed -i "s|ssl-cipher.*|ssl-cipher = TLSv1.2, TLSv1.3|" $CONF
+    #sed -i "\|^ssl|s|^|#|" $CONF
+
+    sed -i "s|ssl-ca.*|ssl-ca = $ca_pem|" $CONF
+    sed -i "s|ssl-cert.*|ssl-cert = $ssl_pem|" $CONF
+    sed -i "s|ssl-key.*|ssl-key = $ssl_key|" $CONF
+
+    # Require SSL for remote user
+    grants=$(mysql -u root --disable-column-names -Be "SHOW GRANTS for $REMOTE_USER@'%';")
+    mysql -u root -e "$grants REQUIRE SSL;"
+}
+
+disable() {
+    sed -i "\|^ssl[- ]|s|^|#|" $CONF
+
+    # Disable SSL requirement for remote user
+    grants=$(mysql -u root --disable-column-names -Be "SHOW GRANTS for $REMOTE_USER@'%';")
+    mysql -u root -e "$grants REQUIRE NONE;"
+}
+
+status() {
+    if grep -q "^ssl =" $CONF || grep -q "^ssl-ciper =" $CONF; then
+        echo 0
+    else
+        echo 10
+    fi
+}
+
+case $1 in
+    enable)
+        enable;;
+    disable)
+        disable;;
+    status)
+        ret_code=$(status)
+        if [[ "$ret_code" -eq 0 ]]; then
+            echo "True"
+            exit $ret_code
+        else
+            echo "False"
+            exit $ret_code
+        fi;;
+    help)
+        usage;;
+    *)
+        if [[ -z "$1" ]]; then
+            echo "Argument required."
+        else
+            echo "Unknown argument: '$1'."
+        fi
+        usage;;
+esac
+
+systemctl restart mysql

--- a/overlay/var/www/index.php
+++ b/overlay/var/www/index.php
@@ -27,6 +27,7 @@
         <div id="container-1">
             <ul>
                 <li><a href="#cp"><span>Control Panel</span></a></li>
+                <li><a href="#docs"><span>Connection Docs</span></a></li>
             </ul>
 
             <div id="cp">
@@ -54,8 +55,119 @@
                         <li><a
                         href="https://www.turnkeylinux.org/mysql">
                         TurnKey MySQL release notes</a></li>
+                        <li>Connection Docs - <a href="#docs">offline</a> / <a
+                        href="https://github.com/turnkeylinux-apps/mysql/tree/master/docs">
+                        online</a></li>
                     </ul>
 
+                </div>
+            </div>
+            <div id="docs">
+                <div class="fragment-content">
+                    <h2>Connection Hints</h2>
+
+                    <p>As per all previous releases, by default TurnKey MySQL (MariaDB) appliance
+                    listens on all interfaces via (default MySQL/MariaDB) port
+                    <strong>3306</strong>.</p>
+
+                    <p>However, since v16.0 there have been some changes...</p>
+
+                    <h3>New remote user username</h3>
+                    As of v16.0+ the default "root-like" user is now named
+                    "<strong>remote</strong>".
+
+                    <h3>SSL now enabled (and required) for the "remote" user</h3>
+
+                    <p>SSL is now enabled and required for remote TCP connections to the
+                    MySQL/MariaDB server. If desired it can be disabled (and re-enabled) via the
+                    Confconsole plugin (Advanced &gt;&gt; System Settings &gt;&gt; MySQL remote
+                    SSL) and/or the 'turnkey-mysql-ssl' commandline tool.</p>
+
+                    <h3>SSL details</h3>
+
+                    <p>Self-signed certificates, signed by a custom CA cert are all generated on
+                    firstboot and stored in '/etc/mysql/certificates'. To connect remotely via SSL,
+                    you will need to download the relevant files and configure your client to use
+                    these, or reconfigure it to your desires. The required files are:</p>
+
+                    <pre>
+/etc/mysql/certificates/ca.pem # The CA certifcate
+/etc/mysql/certificates/cert.pem # The certificate file
+/etc/mysql/certificates/cert.key # The key file</pre>
+
+                    <p>For example, to use the commandline MySQL/MariaDB client from another
+                    TurnKey instance, assuming that the files have been downloaded to the same
+                    local locations, the following lines are required in the MySQL/MariaDB client
+                    config ('/etc/mysql/mariadb.conf.d/50-client.cnf'):</p>
+
+                    <pre>
+ssl_ca = /etc/mysql/certificates/ca.pem
+ssl-cert = /etc/mysql/certificates/cert.pem
+ssl-key = /etc/mysql/certificates/cert.key</pre>
+
+                    <p>Note that the user who is launching the client must have read permission for
+                    these files.</p>
+
+                    <p>Once configured, then connection should work as per usual remote
+                    MySQL/MariaDB connection. E.g.:</p>
+
+                    <pre>
+root@core ~# mysql -h remote-mysql.example.com -u remote -p
+Enter password:
+Welcome to the MariaDB monitor.  Commands end with ; or \g.
+Your MariaDB connection id is 41
+Server version: 10.3.22-MariaDB-0+deb10u1 Debian 10
+
+Copyright (c) 2000, 2018, Oracle, MariaDB Corporation Ab and others.
+
+Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
+
+MariaDB [(none)]></pre>
+
+                    <p>Then to demonstrate that the connection is encrypted, you can use the '\s'
+                    command. I.e.:</p>
+
+                    <pre>
+MariaDB [(none)]> \s
+--------------
+mysql  Ver 15.1 Distrib 10.3.22-MariaDB, for debian-linux-gnu (x86_64) using readline 5.2
+
+Connection id:		41
+Current database:
+Current user:		remote@remote-mysql.example.com
+SSL:			Cipher in use is DHE-RSA-AES256-SHA
+Current pager:		less -X -R -F
+Using outfile:		''
+Using delimiter:	;
+Server:			MariaDB
+Server version:		10.3.22-MariaDB-0+deb10u1 Debian 10
+Protocol version:	10
+Connection:		192.168.1.74 via TCP/IP
+Server characterset:	utf8mb4
+Db     characterset:	utf8mb4
+Client characterset:	utf8mb4
+Conn.  characterset:	utf8mb4
+TCP port:		3306
+Uptime:			34 min 12 sec
+
+Threads: 7  Questions: 77  Slow queries: 0  Opens: 32  Flush tables: 1  Open tables: 26  Queries per second avg: 0.037
+--------------</pre>
+
+                <p>Note the ciper noted against "SSL:"! :)</p>
+
+                <h3>Alternate configurations</h3>
+                There are a number of alternate configrations possible (including using "proper" CA
+                signed certs) but you are on your own with those for now. Please see the <a
+                href="https://mariadb.com/kb/en/securing-connections-for-client-and-server/">
+                MariaDB "Securing Connections" KB page</a> for further ideas.<p>
+
+                <p>If you do configure this appliance to connect via SSL in alternate way and would
+                like to share your config (please do!), and/or have any questions please feel free
+                to post in the <a href="https://www.turnkeylinux.org/forum">TurnKey forums</a>.</p>
+
+                <p>For the most up to date details, please check the <a
+                href="https://www.turnkeylinux.org/mysql">MySQL appliance page</a> and/or the <a
+                href="https://github.com/turnkeylinux-apps/mysql/tree/master/docs">docs</a>.</p>
                 </div>
             </div>
 

--- a/plan/main
+++ b/plan/main
@@ -1,10 +1,7 @@
 #include <turnkey/base>
+#include <turnkey/mysql>
 
-mysql-server
-
-adminer			/* Adminer - Replaces phpPgAdmin */
-lighttpd		/* we use lighty to power adminer */
-php-cgi		/* needed for lighty cgi and adminer depend */
-php-mysql		/* needed for adminer mysql support 
-
-webmin-mysql             /* webmin is in base, give the user the option */
+adminer
+lighttpd                /* landing page and Adminer powered by lighty */
+php-cgi                 /* needed for lighty cgi and adminer depend */
+php-mysql               /* needed for adminer mysql support */


### PR DESCRIPTION
Fairly major update of MySQL appliance for v16.0 Primarily use new `remote` user account fro remote connections and enable (require) SSL for remote connection by default.